### PR TITLE
Use relative squared price weights

### DIFF
--- a/src/smoothing_spline/implementation/spline_model.py
+++ b/src/smoothing_spline/implementation/spline_model.py
@@ -64,8 +64,9 @@ def build_observation_matrix(
     min_price: float = 1e-4,
 ) -> np.ndarray:
     """
-    Builds $W$ (observation weights). 
-    2005 = Identity. 2009 = Diagonal inverse prices (weighted).
+    Builds W (observation weights).
+    2005 = Identity. Weighted mode uses inverse squared floored prices,
+    corresponding to relative squared price errors.
     """
     if fit_mode not in ALLOWED_FIT_MODES:
         raise ValueError(
@@ -76,8 +77,8 @@ def build_observation_matrix(
     if fit_mode == "unweighted":
         return np.identity(n)
 
-    price_floor = np.maximum(call_prices, min_price)
-    return np.diag(1.0 / price_floor)
+    floored_call_prices = np.maximum(call_prices, min_price)
+    return np.diag(1.0 / floored_call_prices**2)
 
 
 def fit_smoothing_spline(

--- a/tests/test_spline_model.py
+++ b/tests/test_spline_model.py
@@ -64,7 +64,7 @@ def test_build_observation_matrix_unweighted():
 def test_build_observation_matrix_weighted_with_floor():
     prices = np.array([100.0, 0.25, 2.0])
     W = build_observation_matrix(prices, fit_mode="weighted", min_price=1.0)
-    expected = np.diag([0.01, 1.0, 0.5])
+    expected = np.diag([0.0001, 1.0, 0.25])
     np.testing.assert_allclose(W, expected, atol=1e-12)
 
 


### PR DESCRIPTION
Corrected a mistake I made last week to do with the weights. Was 1 /CP now 1/CP^2 as it should be